### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/kenneth0860/99fee728-2cd9-4ed0-ac3c-56ef2533baa3/e3c74de1-e20d-4df7-a1c9-d89148d73f15/_apis/work/boardbadge/645cfa8d-8e7c-4074-a68b-00edcd4f84cd)](https://dev.azure.com/kenneth0860/99fee728-2cd9-4ed0-ac3c-56ef2533baa3/_boards/board/t/e3c74de1-e20d-4df7-a1c9-d89148d73f15/Microsoft.RequirementCategory)
 # hetzner-cloud-api-client
 API Client for managing Hetzner's Cloud
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/kenneth0860/99fee728-2cd9-4ed0-ac3c-56ef2533baa3/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.